### PR TITLE
Feat add tx mute feedback

### DIFF
--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -3,6 +3,7 @@
 ## Getting started
 
 Just select the device from the module config window and enter the control IP of your EM2/EM4 receiver or network charger and press 'Save'. To control multiple devices, just add the connection several times to your Companion instance.
+For receivers with firmware >= 4.0.0 : please enable the "Legacy Mode" in the Sennheiser WSM Software for the receiver, to be able to control the devices using the SCP v1 protocol. If this is not done, you can't control your devices via Companion at this point.
 
 ### Variables
 

--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -3,7 +3,7 @@
 	"name": "sennheiser-ewdx",
 	"shortname": "sennheiser-ewdx",
 	"description": "Control devices of the Sennheiser EW-DX Series",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"license": "MIT",
 	"repository": "git+https://github.com/bitfocus/companion-module-sennheiser-ewdx.git",
 	"bugs": "https://github.com/bitfocus/companion-module-sennheiser-ewdx/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "companion-module-sennnheiser-ewdx",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"main": "dist/main.js",
 	"type": "module",
 	"scripts": {

--- a/src/feedbacks.ts
+++ b/src/feedbacks.ts
@@ -90,6 +90,26 @@ export function UpdateFeedbacks(self: ModuleInstance): void {
 				return receiver.linkDensityMode
 			},
 		}
+		feedbacks.tx_muted = {
+			name: 'TX: Muted',
+			type: 'boolean',
+			defaultStyle: {
+				bgcolor: combineRgb(0, 255, 0),
+			},
+			options: [
+				{
+					id: 'receiver',
+					type: 'dropdown',
+					label: 'Receiver Channel',
+					default: 0,
+					choices: getChannelOptions(),
+				},
+			],
+			callback: (feedback) => {
+				const channel = Number(feedback.options.receiver)
+				return receiver.channels[channel].mate.muted
+			},
+		}
 		feedbacks.rx_encryption_error = {
 			name: 'RX: Encryption Error',
 			description: 'Becomes active if an encryption error occurs on the selected channel',
@@ -153,26 +173,7 @@ export function UpdateFeedbacks(self: ModuleInstance): void {
 				return receiver.channels[channel].identification
 			},
 		}
-		feedbacks.rx_muted = {
-			name: 'RX: Muted',
-			type: 'boolean',
-			defaultStyle: {
-				bgcolor: combineRgb(0, 255, 0),
-			},
-			options: [
-				{
-					id: 'receiver',
-					type: 'dropdown',
-					label: 'Receiver Channel',
-					default: 0,
-					choices: getChannelOptions(),
-				},
-			],
-			callback: (feedback) => {
-				const channel = Number(feedback.options.receiver)
-				return receiver.channels[channel].muted
-			},
-		}
+
 		feedbacks.tx_mute_config_sk = {
 			name: 'RX: Mute Config [SK(M)]',
 			type: 'boolean',


### PR DESCRIPTION
Removed the RX: Muted feedback and added the "TX: Muted" feedback - because the RX mute variable is not used by the device, although it exists.