### PR TITLE
Dynamically bind source/sender UDP port

### DIFF
--- a/src/ewdx.ts
+++ b/src/ewdx.ts
@@ -143,7 +143,7 @@ export abstract class EWDX {
 	}
 
 	private setupListeners() {
-		this.socket.bind(udpPort, this.host, () => {
+		this.socket.bind(0, this.host, () => {
 			console.log('Socket successfully connected.')
 		})
 


### PR DESCRIPTION
Dynamically bind source/sender port to fix bind error on linux based companion host.

With this fix I'm able to connect on a Raspberry Pi 5 with Companion Pi.
Also tested compatibility on Windows 11 and macOS 26.